### PR TITLE
レイアウト変更その他

### DIFF
--- a/extensions-builtin/mobile/javascript/mobile.js
+++ b/extensions-builtin/mobile/javascript/mobile.js
@@ -1,26 +1,105 @@
-var isSetupForMobile = false;
+/**
+ * id指定のDOMを from -> to へ移動する関数
+ * 
+ * @param {string} from 移動させたいDOMのCSSSelector 
+ * @param {string} to 移動先のDOMのCSSSelector
+ * @param {string} operation 操作 (firstChild = 子要素の先頭, lastChild = 子要素の末尾)
+ * @param {number} fromIndex 要素が複数見つかった時用に指定するindex
+ * @param {number} toIndex 要素が複数見つかった時用に指定するindex
+ * @returns 早期リターン
+ */
+function moveDOM(from, to, operation, fromIndex = 0, toIndex = 0) {
+    const fromObjectNodeList = gradioApp().querySelectorAll(from);
+    const fromObject = fromObjectNodeList?.item(fromIndex);
 
-function isMobile() {
-    for (var tab of ["txt2img", "img2img"]) {
-        var imageTab = gradioApp().getElementById(tab + '_results');
-        if (imageTab && imageTab.offsetParent && imageTab.offsetLeft == 0) {
-            return true;
-        }
+    const targetObjectNodeList = gradioApp().querySelectorAll(to);
+    const targetObject = targetObjectNodeList?.item(toIndex);
+
+    if (!fromObject || !targetObject) {
+        console.log('moveDOM(): fromDOM or targetDOM was not found.');
+        return;
     }
 
-    return false;
-}
+    if (operation === 'firstChild') {
+        targetObject.insertBefore(fromObject, targetObject.firstElementChild);
+    }
 
-function reportWindowSize() {
-    var currentlyMobile = isMobile();
-    if (currentlyMobile == isSetupForMobile) return;
-    isSetupForMobile = currentlyMobile;
-
-    for (var tab of ["txt2img", "img2img"]) {
-        var button = gradioApp().getElementById(tab + '_generate_box');
-        var target = gradioApp().getElementById(currentlyMobile ? tab + '_results' : tab + '_actions_column');
-        target.insertBefore(button, target.firstElementChild);
+    if (operation === 'lastChild') {
+        targetObject.appendChild(fromObject);
     }
 }
 
-window.addEventListener("resize", reportWindowSize);
+/**
+ * 画面が読み込まれた後にレイアウトを変更する関数
+ * 
+ * @returns boolean 変更が完了したか
+ */
+function fixLayouts() {
+    console.log(`fixLayouts applying...: ${new Date()}`);
+
+    if (!gradioApp().querySelector('#txt2img_styles_row')) {
+        return false;
+    }
+
+    // Stylesはプロンプト入力欄の先頭に移動
+    moveDOM('#txt2img_styles_row', '#txt2img_prompt_container', 'firstChild');
+
+    // Generateボタンはプロンプト入力欄の先頭に移動
+    moveDOM('#txt2img_generate_box', '#txt2img_prompt_container', 'firstChild');
+
+    // Easy-Generateボタンはプロンプト入力欄の先頭に移動 (Extension)
+    moveDOM('#txt2img_actions_column > div.easy_generate_forever_container', '#txt2img_prompt_container', 'firstChild');
+
+    // 花札とかのボタンはプロンプト入力欄の末尾に移動
+    moveDOM('#txt2img_tools', '#txt2img_prompt_container', 'lastChild');
+
+    // LoRAとか選ぶフレームは花札の下に移動 (花札とフレームが同じID使ってるので、indexを指定)
+    moveDOM('#txt2img_extra_networks', '#txt2img_prompt_container', 'lastChild', 1);
+    
+    // プレビュー画像の部分をGenerateボタンとかあるとこの末尾に移動
+    moveDOM('#txt2img_results', '#txt2img_actions_column', 'lastChild');
+    
+    // txt2img_prompt_containerのGRID指定を消して、上半分のレイアウトを半々にする
+    const txt2imgPromptContainer = gradioApp().getElementById('txt2img_prompt_container');
+    txt2imgPromptContainer.style.flexGrow = null;
+
+    // 花札の右側のマージンを消す
+    const hanafuda = gradioApp().getElementById('txt2img_tools');
+    hanafuda.style.width = 'fit-content';
+
+    // 花札はGenerateForeverの左側に移動 *注意: Extensionに依存しているので、アップデートに注意
+    moveDOM('#txt2img_tools', '#txt2img_prompt_container > div.easy_generate_forever_container > div', 'firstChild');
+
+    // 保存ボタンとかはめったに使わないのでresultの末尾に移動
+    moveDOM('#image_buttons_txt2img', '#txt2img_results', 'lastChild');
+
+    return true;
+}
+
+/**
+ * fixLayouts() が成功するまで画面をウォッチする関数
+ */
+function fixLayoutsObserver() {
+    const observer = new MutationObserver((mutationsList, observer) => {
+        const childListMutation = mutationsList.find(mutation => mutation.type === 'childList');
+        if (!childListMutation) return;
+
+        const isFoundTargetDOM = fixLayouts();
+        if (!isFoundTargetDOM) return;
+
+        // MutationObserverのウォッチを解除
+        observer.disconnect();
+    });
+
+    // ウォッチ対象の親要素を取得
+    const parentElement = gradioApp();
+
+    // MutationObserverの設定
+    const config = { childList: true };
+
+    // MutationObserverを開始
+    observer.observe(parentElement, config);
+}
+
+// ウォッチ関数を登録
+document.addEventListener("DOMContentLoaded", fixLayoutsObserver);

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -16,12 +16,16 @@ function setupExtraNetworksForTab(tabname) {
     tabs.appendChild(sortOrder);
     tabs.appendChild(refresh);
 
+    /**
+     * ExtraNetworkの検索ボックスで文字列を検索する
+     * デフォルトとの差分: descriptionも検索対象に入れる
+     */
     var applyFilter = function() {
         var searchTerm = search.value.toLowerCase();
 
         gradioApp().querySelectorAll('#' + tabname + '_extra_tabs div.card').forEach(function(elem) {
             var searchOnly = elem.querySelector('.search_only');
-            var text = elem.querySelector('.name').textContent.toLowerCase() + " " + elem.querySelector('.search_term').textContent.toLowerCase();
+            var text = `${elem.querySelector('.name').textContent.toLowerCase()} ${elem.querySelector('.search_term').textContent.toLowerCase()} ${elem.querySelector('.description').textContent}`;
 
             var visible = text.indexOf(searchTerm) != -1;
 

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -28,10 +28,31 @@ function selected_gallery_button() {
     });
     return visibleCurrentButton;
 }
-
+  
+/**
+ * txt2imgのサムネイルを押した時のアクション
+ */
 function selected_gallery_index() {
     var buttons = all_gallery_buttons();
     var button = selected_gallery_button();
+
+    // 書き換え後のプレビュー画像のサイズ
+    const previewSize = "1024px";
+
+    // プレビュー画像のサイズを広げる
+    const txt2imgGalleryPreviewImage = Array.from(gradioApp()?.querySelectorAll('#txt2img_gallery > div.preview'))
+        .filter(element => /svelte-.*/.test(element?.classList?.value))?.[0];
+
+    if(txt2imgGalleryPreviewImage){
+        txt2imgGalleryPreviewImage.style.minHeight = previewSize;
+    }
+
+    // プレビュー画像の外枠のサイズも広げる
+    const txt2imgGalleryPreviewOuterFrame = gradioApp()?.querySelectorAll('#txt2img_gallery')?.[0];
+
+    if(txt2imgGalleryPreviewOuterFrame){
+        txt2imgGalleryPreviewOuterFrame.style.minHeight = previewSize;
+    }
 
     var result = -1;
     buttons.forEach(function(v, i) {

--- a/style.css
+++ b/style.css
@@ -767,7 +767,7 @@ footer {
 /* extra networks UI */
 
 .extra-network-cards{
-    height: 725px;
+    height: 440px;
     overflow: scroll;
     resize: vertical;
 }
@@ -861,8 +861,8 @@ footer {
 .extra-network-cards .card, .standalone-card-preview.card{
     display: inline-block;
     margin: 0.5rem;
-    width: 16rem;
-    height: 24rem;
+    width: 9rem;
+    height: 12rem;
     box-shadow: 0 0 5px rgba(128, 128, 128, 0.5);
     border-radius: 0.2rem;
     position: relative;
@@ -899,7 +899,7 @@ footer {
 }
 
 .extra-network-cards .card .actions .name{
-    font-size: 1.7em;
+    font-size: 1.0em;
     font-weight: bold;
     line-break: anywhere;
 }
@@ -908,7 +908,8 @@ footer {
     display: block;
     max-height: 3em;
     white-space: pre-wrap;
-    line-height: 1.1;
+    line-height: 1.0;
+    font-size: 0.8em;
 }
 
 .extra-network-cards .card .actions .description:hover {

--- a/style.css
+++ b/style.css
@@ -770,9 +770,22 @@ footer {
 /* extra networks UI */
 
 .extra-network-cards{
-    height: 440px;
+    height: 872px;
     overflow: scroll;
     resize: vertical;
+}
+
+/* スクロールバーの色を変更 */
+::-webkit-scrollbar{
+    width: 10px;
+}
+
+::-webkit-scrollbar-track{
+    background-color: #0b0f19;
+}
+
+::-webkit-scrollbar-thumb{
+    background-color: #111827;
 }
 
 .extra-networks > div > [id *= '_extra_']{

--- a/style.css
+++ b/style.css
@@ -263,7 +263,8 @@ button.custom-button{
 }
 
 #txt2img_generate, #img2img_generate {
-    min-height: 4.5em;
+    height: 1.7em;
+    flex-wrap: nowrap;
 }
 
 @media screen and (min-width: 2500px) {
@@ -299,10 +300,12 @@ button.custom-button{
     width: 50%;
     height: 100%;
     display: none;
-    background: #b4c0cc;
+    background: #4e4e4e;
+    font-size: inherit;
+    padding: inherit;
 }
 .gradio-button.generate-box-skip:hover, .gradio-button.generate-box-interrupt:hover{
-    background: #c2cfdb;
+    background: #5e5e5e;
 }
 .gradio-button.generate-box-interrupt{
     left: 0;


### PR DESCRIPTION
## 修正点

- txt2imgのレイアウトを全体的に変更
  - プレビューを大きく
  - GenerateボタンをPositiveの上に移動 & 小さく
  - ExtraNetworkをNegativeの下に移動 & カードを小さく変更

- `mobile.js` がGenerateボタンの移動を切り戻してたので、リスナと関数を削除
- LoRAの検索対象に `description` も含めるように変更